### PR TITLE
Sample structure for component types

### DIFF
--- a/src/components/html-components/h-button-dropdown/readme.md
+++ b/src/components/html-components/h-button-dropdown/readme.md
@@ -1,0 +1,1 @@
+Just a file to make it possible to commit this folder.

--- a/src/components/html-components/h-dropdown/readme.md
+++ b/src/components/html-components/h-dropdown/readme.md
@@ -1,0 +1,1 @@
+Just a file to make it possible to commit this folder.

--- a/src/components/html-components/h-loading/readme.md
+++ b/src/components/html-components/h-loading/readme.md
@@ -1,0 +1,1 @@
+Just a file to make it possible to commit this folder.

--- a/src/components/html-components/readme.md
+++ b/src/components/html-components/readme.md
@@ -1,0 +1,1 @@
+Just a file to make it possible to commit this folder.

--- a/src/components/javascript-components/j-datepicker/readme.md
+++ b/src/components/javascript-components/j-datepicker/readme.md
@@ -1,0 +1,1 @@
+Just a file to make it possible to commit this folder.

--- a/src/components/javascript-components/j-table/readme.md
+++ b/src/components/javascript-components/j-table/readme.md
@@ -1,0 +1,1 @@
+Just a file to make it possible to commit this folder.

--- a/src/components/javascript-components/readme.md
+++ b/src/components/javascript-components/readme.md
@@ -1,0 +1,1 @@
+Just a file to make it possible to commit this folder.


### PR DESCRIPTION
This is just a sample structure to be discussed, for storing other components than of custom-elements type. There is no urgent need to approve this pull-request but I do want it to be discussed.

It would make some sense to have typing on the component name:

j-     for javascript-components (this folder could possibly be called only javascript.
h-    for HTML-components (perphaps only called only html?
c-    for custom-elements.

Different types of components can be viewed here (on the tabs):
https://scania.github.io/corporate-ui-docs/developer/bootstrap-original-docs.html

The source/sample code needs to be stored somewere. I am not sure if these folders are the place though...

What do you think?

/Jepser


