### PR TITLE
Travis deploy for s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,69 @@
-language: node_js
-node_js:
-  - "8"
+#Xenial for upgraded pip -v
+dist: xenial
+language: python
+python:
+  - "3.6"
 
-script:
+# Whitelist branch
+branches:
+ only:
+ - master
+ - /(improvement|bug|feature)\/(:?[\S]*)/
+ - /(\d+.\d+.\d+)(\S*)?/
+
+before_script:
+  - "echo Build ID# $TRAVIS_BUILD_ID Branch-Name: $TRAVIS_BRANCH"
+  - "echo Commit#: $TRAVIS_COMMIT Commit-message: $TRAVIS_COMMIT_MESSAGE"
+  - "echo Tag-name: $TRAVIS_TAG If it exist"
   - "npm i"
+
+# NPM setup for building dist
+script:
   - "npm run build"
+  - "echo Testing"
   - "npm run test"
-  - "echo $TRAVIS_BRANCH"
-  - "echo $AWS_KEY_ID"
 
+# Removing the current folder uploaded
+# Needs pip -v 10+ at least
+# Run only if it isn't a tag
+before_deploy:
+# - pip install --upgrade pip
+- |
+  if [ -z "$TRAVIS_TAG" ]; then
+    pip install awscli
+    aws configure set aws_access_key_id $AWS_KEY_ID
+    aws configure set aws_secret_access_key $AWS_KEY_SECRET
+    aws configure set default.region $AWS_DEFAULT_REGION
+    aws s3 rm --recursive s3://corporate-ui-deploy-test/build/global/branch/$TRAVIS_BRANCH
+  fi
+#Deploy for S3 on AWS for branches and releases
+#Not for PR
+
+#Deploy for branches
 deploy:
-  provider: s3
-  access_key_id: "$AWS_KEY_ID"
-  secret_access_key: "$AWS_KEY_SECRET"
-  bucket: "corporate-ui-deploy-test"
-  region: "eu-west-1"
-  local_dir: "dist"
-  upload_dir: "build/global/$TRAVIS_BRANCH"
-  skip_cleanup: true
-  acl: public_read
-  on:
-    branch: $TRAVIS_BRANCH
+  - provider: s3
+    access_key_id: "$AWS_KEY_ID"
+    secret_access_key: "$AWS_KEY_SECRET"
+    bucket: "corporate-ui-deploy-test"
+    region: "eu-west-1"
+    local_dir: "dist"
+    upload_dir: "build/global/branch/$TRAVIS_BRANCH"
+    skip_cleanup: true
+    acl: public_read
+    on:
+      branch: $TRAVIS_BRANCH
+      tags: false
 
-# deploy:
-#   provider: npm
-#   email: "andreas.wikstrom@scania.com"
-#   api_key: "$NPM_ACCESS_KEY"
-#   on:
-#     branch: master
+#Deploy for releases
+  - provider: s3
+    access_key_id: "$AWS_KEY_ID"
+    secret_access_key: "$AWS_KEY_SECRET"
+    bucket: "corporate-ui-deploy-test"
+    region: "eu-west-1"
+    local_dir: "dist"
+    upload_dir: "build/global/releases/$TRAVIS_TAG"
+    skip_cleanup: true
+    acl: public_read
+    on:
+      branch: $TRAVIS_TAG
+      tags: true


### PR DESCRIPTION
**Describe pull-request**</br>
Making travis deploy either release or branch to a specific folder on s3 bucket

- We have a list of branches that are allowed to be pushed into s3 
- - ` - master`
` - /(improvement|bug|feature)\/(:?[\S]*)/`
` - /(\d+.\d+.\d+)(\S*)?/`
- Installing dependecies for corporate-ui before_script
- Running the build command to create the dist folder
- Before_deploy phase check if the branch is a including a tag(release tag)
- -  if doesn't it will remove the previous dist folder that was commited
- - if the tag doesn't exist `if [ -z "$TRAVIS_TAG" ]; then` it will run the before_deploy section, 
- During deploy phase, it will deploy dist to s3 bucket.
- - If the branch is a release then it will create inside the build/global/release folder 
- - It will deploy the dist folder with public-read


**Solving issue**</br>
Fixes: #39 

**Additional context**<br/>
Keep in mind what commands that run, if something changes in the master, either removing a command or adding a new one, we probebly need to add in the script section of travis.yml also

Pull-request are also build, but travis sees that it isn't a branch or release(tag) so it will skip the deploy section completely.

We need to run `Dist: Xenial` for having a later PIP version, to reduce the build time