### PR TITLE
Bug FIX - border right

### DIFF
--- a/src/themes/scania/c-navigation.scss
+++ b/src/themes/scania/c-navigation.scss
@@ -203,7 +203,7 @@ ul {
   ::slotted(a[slot="secondary-items"]):before {
     border-left: 0;
   }
-  ::slotted(a[slot="secondary-items"]:not(:last-child)):after {
+  ::slotted(a[slot="secondary-items"]:not(:last-of-type)):after {
     border-right: 1px solid #e2e2e2;
   }
 


### PR DESCRIPTION
Fix for https://github.com/scania/corporate-ui-dev/issues/123

**Describe pull-request**</br>
Change a selector to be :last-of-type instead of :last-child that way it will look only when that specific element is last (when it is first and only one it shouldn´t have a right border as well, which this fix now resolves that)

**Solving issue**</br>
Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)
Fixes: #123 