### PR TITLE
Add short name for c-header

### DIFF
--- a/public/components/c-header.js
+++ b/public/components/c-header.js
@@ -1,7 +1,7 @@
 export default {
   title: 'Header',
   description: [
-    'A header display a logotype, site name, item links, and a symbol. The site name will be displayed on the right hand side of the logotype on desktop mode and top centered in mobile mode. You can add one or several link items to the header that will be displayed at the right side of the header. This location is also used for language selectors and user menus.',
+    'A header display a logotype, site name, short-name, item links, and a symbol. The site name will be displayed on the right hand side of the logotype on desktop mode. Short name will be placed at the top centered in mobile mode. You can add one or several link items to the header that will be displayed at the right side of the header. This location is also used for language selectors and user menus.',
     'There are two ways to populate link items, by adding JSON objects to item attribute, or by having it in slot="items". See examples below to understand different ways of displaying header component.',
     'To include navigation component in the header as a main navigation, you need to define the slot name such as slot = "navigation". The navigation is a responsive component. If you make your browser window narrower you will see how the navigation changes its appearance on mobile view.',
   ],
@@ -11,7 +11,8 @@ export default {
       title: 'Items as data',
       content: `
 <c-header
-  site-name='Name'
+  site-name='Application'
+  short-name='App'
   items='[{ "text": "global", "href": "/" }, { "text": "scania", "href": "/" }]'></c-header>
       `,
     },
@@ -84,7 +85,8 @@ export default {
                     as well as sub level in the navigation.`,
       content: `
 <c-header
-  site-name='Name'>
+  site-name='Application'
+  short-name='App'>
   <a href="/" slot="items">global</a>
   <a href="/" slot="items">scania</a>
 

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -24,6 +24,10 @@ c-navigation {
   background-image: $navbar-light-toggler-icon-bg;
 }
 
+.navbar-default[short-name]:after {
+  content: attr(short-name);
+}
+
 @media (min-width: 992px) {
   .navbar-expand-lg .navbar-brand {
     display: inline-block;

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -23,6 +23,9 @@ export class Header {
   /** Header links that will be placed in the top right part of the header */
   @Prop() items: any;
 
+  /** Short name will be displayed in the top-centered of the header on mobile mode */
+  @Prop() shortName: string;
+
   @State() currentTheme: string = this.theme || store.getState().theme.name;
 
   @State() navigationOpen: Boolean;
@@ -89,7 +92,7 @@ export class Header {
     return [
       this.currentTheme ? <style>{ themes[this.currentTheme] }</style> : '',
 
-      <nav class='navbar navbar-expand-lg navbar-default'>
+      <nav class='navbar navbar-expand-lg navbar-default' short-name={this.shortName}>
         {this.navigationSlot.length
           ? <button
             class='navbar-toggler collapsed'

--- a/src/themes/scania/c-header.scss
+++ b/src/themes/scania/c-header.scss
@@ -60,7 +60,7 @@ c-navigation {
       height: 28px;
     }
   }
-  .navbar-title {
+  .navbar-title, &:after {
     font-family: 'Scania Sans Headline';
     font-weight: normal;
     font-size: 1.8rem;
@@ -90,6 +90,11 @@ c-navigation {
         }
       }
     }
+  }
+}
+.navbar-default[short-name] {
+  .navbar-title {
+    display: none;
   }
 }
 .navbar-symbol {
@@ -148,7 +153,16 @@ c-navigation {
       border-left: 1px solid #e2e2e2;
       padding-left: 15px;
     }
+    &[short-name] {
+      .navbar-title{
+        display:inline-block;
+      }
+      &:after {
+        display: none;
+      }
+    }
   }
+  
   .navbar-symbol {
     position: sticky;
     top: 0;


### PR DESCRIPTION
- Added properties short-name in the c-header
- Added styling to display short-name in mobile

**Describe pull-request**</br>
Dsiplay short-name when it is added as a property in c-header. Short name will be displayed in mobile mode. When short-name is not stated, default site-name is shown in mobile mode.


**Solving issue**</br>
Fixes: #93 


**Additional context**<br/>
How to test:
- Go to [link](https://d1kybmg72qo0dt.cloudfront.net/build/global/branch/improvement/Short_name_in_header/www/index.html?selectedKind=Components&selectedStory=Header&full=0&addons=0&stories=1&panelRight=0)
- Check on mobile view
- See the first example & last example, header title changed to the short-name in mobile mode
