### PR TITLE
Added data-env styling in c-theme

### DIFF
--- a/public/preview-head.html
+++ b/public/preview-head.html
@@ -28,4 +28,5 @@
       }
     }
   })();
+  document.body.setAttribute('data-env','dev');
 </script>

--- a/src/components/theme/theme.scss
+++ b/src/components/theme/theme.scss
@@ -59,34 +59,6 @@ body[data-env]:before {
   text-transform: uppercase;
 }
 
-body[data-env=dev]:before,
-body[data-env=proj]:before,
-body[data-env=demo]:before,
-body[data-env=proto]:before,
-body[data-env=development]:before,
-body[data-env^=beta]:before {
-  background-color: var(--info-02);
-  color: var(--info-04);
-  border-color: var(--info-03);
-}
-
-body[data-env=sys]:before {
-  background-color: var(--success-02);
-  color: var(--success-04);
-  border-color: var(--success-03);
-}
-
-body[data-env=acc]:before,
-body[data-env=pre]:before {
-  background-color: var(--warning-02);
-  color: var(--warning-04);
-  border-color: var(--warning-03);
-}
-
-body[data-env=proto]:before {
-  font-size: 10px;
-}
-
 body[data-env=""]:before,
 body[data-env=prod]:before,
 body[data-env=production]:before,

--- a/src/components/theme/theme.scss
+++ b/src/components/theme/theme.scss
@@ -38,6 +38,65 @@
     'Liberation Mono', 'Courier New', monospace;
 }
 
+// data environment
+body[data-env]:before {
+  background-color: #ddd;
+  border: 2px solid #fafafa;
+  display: inline-block;
+  font-size: 14px;
+  font-weight: bold;
+  padding: 52px 50px 2px;
+  content: attr(data-env);
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1170;
+  -ms-transform: translateY(-50%) translateX(-50%) rotate(-45deg);
+  -moz-transform: translateY(-50%) translateX(-50%) rotate(-45deg);
+  -webkit-transform: translateY(-50%) translateX(-50%) rotate(-45deg);
+  -o-transform: translateY(-50%) translateX(-50%) rotate(-45deg);
+  transform: translateY(-50%) translateX(-50%) rotate(-45deg);
+  text-transform: uppercase;
+}
+
+body[data-env=dev]:before,
+body[data-env=proj]:before,
+body[data-env=demo]:before,
+body[data-env=proto]:before,
+body[data-env=development]:before,
+body[data-env^=beta]:before {
+  background-color: var(--info-02);
+  color: var(--info-04);
+  border-color: var(--info-03);
+}
+
+body[data-env=sys]:before {
+  background-color: var(--success-02);
+  color: var(--success-04);
+  border-color: var(--success-03);
+}
+
+body[data-env=acc]:before,
+body[data-env=pre]:before {
+  background-color: var(--warning-02);
+  color: var(--warning-04);
+  border-color: var(--warning-03);
+}
+
+body[data-env=proto]:before {
+  font-size: 10px;
+}
+
+body[data-env=""]:before,
+body[data-env=prod]:before,
+body[data-env=production]:before,
+body[data-env=hidden]:before {
+  display:none;
+}
+
+body[data-env=development]:before {
+  content: "dev";
+}
 
 // Copied from bootstrap mixin grid framework and modified to support prefix and sufix
 // @mixin make-grid-columns(


### PR DESCRIPTION
- Added styling if data-env exist in the body
- Added data-env in storybook

**Solving issue**</br>

Fixes: #164 


**Solution**<br/>
1. Add data-env attribute in body, such as <body data-env="dev">
2. Styles will be implemented based on the content
3. Different background color available for following environment:
   * dev / development
   * proj
   * demo
   * proto
   * beta
   * sys
   * acc
   * pre

4. Production label will be hidden
5. Default styling is with gray background-color
