### PR TITLE
Fix big dealer logo image cause visible flashing content

### DIFF
--- a/src/components/dealer-header/dealer-header.scss
+++ b/src/components/dealer-header/dealer-header.scss
@@ -1,1 +1,6 @@
 @import '../../components.scss';
+
+// TODO: Review this when FOUC is solved or when we work on initial styling
+img {
+  max-height: 30px;
+}


### PR DESCRIPTION
- Added max-height for dealer logo image on initial styling